### PR TITLE
check current balance for total to support same token swap

### DIFF
--- a/src/integrations/UniV3Swap.sol
+++ b/src/integrations/UniV3Swap.sol
@@ -76,7 +76,7 @@ contract UniV3Swap is ISwapperFlashCallback {
         FlashCallbackData memory flashCallbackData = abi.decode(data_, (FlashCallbackData));
 
         ISwapRouter.ExactInputParams[] memory exactInputParams = flashCallbackData.exactInputParams;
-        uint256 totalOut;
+        uint256 totalOut = tokenToBeneficiary_._balanceOf(address(this));
         uint256 length = exactInputParams.length;
         for (uint256 i; i < length;) {
             ISwapRouter.ExactInputParams memory eip = exactInputParams[i];


### PR DESCRIPTION
I think this change is needed to support "swapping" a token for itself. Otherwise `totalOut` never gets updated since no uniswap calls are happening.

I'm not sure if this opens up any issues though? Don't think so, still thinking through it a bit. Not sure how to handle a same token swap without a change like this though.